### PR TITLE
api handler class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ logs
 
 node_modules
 bower_components
+coverage
 
 *.sublime*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
         "bootstrap": "^5.0.2",
+        "jest": "^26.6.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
     "bootstrap": "^5.0.2",
+    "jest": "^26.6.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -1,0 +1,51 @@
+class Api {
+
+    constructor(authToken) {
+      this.authToken = authToken;
+    }
+  
+    headers = {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    };
+  
+    BASE_URL = '/api';
+  
+    createHeaders() {
+      return this.authToken ? {
+        ...this.headers,
+        'Authorization': 'Bearer ' + this.authToken
+      } : this.headers;
+    }
+  
+    async getArtworks() {
+      return await fetch(`${this.BASE_URL}/artworks`, {
+        method: 'GET',
+        headers: this.createHeaders()
+      });
+    }
+
+    async getArtworkByName(name) {
+      return await fetch(`${this.BASE_URL}/artworks/${name}`, {
+        method: 'GET',
+        headers: this.createHeaders()
+      });
+    }
+  
+    async getArtworkByAlbum(album) {
+      return await fetch(`${this.BASE_URL}/artworks/album/${album}`, {
+        method: 'GET',
+        headers: this.createHeaders()
+      });
+    }
+  
+    async addArtwork(artwork) {
+      return await fetch(this.BASE_URL, {
+        method: 'POST',
+        headers: this.createHeaders(),
+        body: JSON.stringify(artwork)
+      });
+    }
+  }
+  
+  export default Api;

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -10,9 +10,8 @@ class Api {
       'Content-Type': 'application/json'
     };
     
-    // this is invalid as it stands, but we should discuss if we want to prepend 
-    // all api endpoints with api/ to keep them distinct from front end routes
-    BASE_URL = '/api';
+    // if we ever prepend /api/ then we can add that here
+    BASE_URL = '';
     
     // create request headers. puts the auth token inside if it is present
     createHeaders() {

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -1,5 +1,6 @@
 class Api {
 
+    // we don't currently handle auth tokens on the back end, but we should
     constructor(authToken) {
       this.authToken = authToken;
     }
@@ -8,16 +9,22 @@ class Api {
       'Accept': 'application/json',
       'Content-Type': 'application/json'
     };
-  
+    
+    // this is invalid as it stands, but we should discuss if we want to prepend 
+    // all api endpoints with api/ to keep them distinct from front end routes
     BASE_URL = '/api';
-  
+    
+    // create request headers. puts the auth token inside if it is present
     createHeaders() {
       return this.authToken ? {
         ...this.headers,
         'Authorization': 'Bearer ' + this.authToken
       } : this.headers;
     }
-  
+    
+
+    // api requests
+
     async getArtworks() {
       return await fetch(`${this.BASE_URL}/artworks`, {
         method: 'GET',
@@ -38,7 +45,8 @@ class Api {
         headers: this.createHeaders()
       });
     }
-  
+    
+    // the body may need to be adjusted here
     async addArtwork(artwork) {
       return await fetch(this.BASE_URL, {
         method: 'POST',

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -23,7 +23,7 @@ class Api {
     }
     
 
-    // api requests
+    // artwork api requests
 
     async getArtworks() {
       return await fetch(`${this.BASE_URL}/artworks`, {
@@ -55,5 +55,7 @@ class Api {
       });
     }
   }
+
+  // music api requests
   
   export default Api;

--- a/src/api/Api.test.js
+++ b/src/api/Api.test.js
@@ -1,0 +1,86 @@
+import Api from './Api';
+
+const apiWithAuthToken = new Api('auth token');
+const apiWithoutAuthToken = new Api();
+
+describe('getArtworks function', () => {
+    it('auth token present fetch is called', async () => {
+       global.fetch = jest.fn(() => {
+          Promise.resolve();
+       });
+       await apiWithAuthToken.getArtworks();
+       expect(fetch).toHaveBeenCalledTimes(1);
+    });
+    it('auth token not present fetch is called', async () => {
+        global.fetch = jest.fn(() => {
+           Promise.resolve();
+        });
+        await apiWithoutAuthToken.getArtworks();
+        expect(fetch).toHaveBeenCalledTimes(1);
+     });
+});
+
+describe('getArtworkByName function', () => {
+    it('auth token present fetch is called', async () => {
+       global.fetch = jest.fn(() => {
+          Promise.resolve();
+       });
+       const name = 'chill name';
+       await apiWithAuthToken.getArtworkByName(name);
+       expect(fetch).toHaveBeenCalledTimes(1);
+    });
+    it('auth token not present fetch is called', async () => {
+        global.fetch = jest.fn(() => {
+           Promise.resolve();
+        });
+        const name = 'chill name';
+        await apiWithoutAuthToken.getArtworkByName(name);
+        expect(fetch).toHaveBeenCalledTimes(1);
+     });
+});
+
+describe('getArtworkByAlbum function', () => {
+    it('auth token present fetch is called', async () => {
+       global.fetch = jest.fn(() => {
+          Promise.resolve();
+       });
+       const album = 'chill album';
+       await apiWithAuthToken.getArtworkByAlbum(album);
+       expect(fetch).toHaveBeenCalledTimes(1);
+    });
+    it('auth token not present fetch is called', async () => {
+        global.fetch = jest.fn(() => {
+           Promise.resolve();
+        });
+        const album = 'chill album';
+        await apiWithoutAuthToken.getArtworkByAlbum(album);
+        expect(fetch).toHaveBeenCalledTimes(1);
+     });
+});
+
+describe('addArtwork function', () => {
+    it('auth token present fetch is called', async () => {
+       global.fetch = jest.fn(() => {
+          Promise.resolve();
+       });
+       const artwork = {
+           name: 'chill name',
+           album: 'chill album',
+           file: '0101010101010'
+       };
+       await apiWithAuthToken.addArtwork(artwork);
+       expect(fetch).toHaveBeenCalledTimes(1);
+    });
+    it('auth token not present fetch is called', async () => {
+        global.fetch = jest.fn(() => {
+           Promise.resolve();
+        });
+        const artwork = {
+            name: 'chill name',
+            album: 'chill album',
+            file: '0101010101010'
+        };
+        await apiWithoutAuthToken.addArtwork(artwork);
+        expect(fetch).toHaveBeenCalledTimes(1);
+     });
+});

--- a/src/api/Api.test.js
+++ b/src/api/Api.test.js
@@ -1,8 +1,11 @@
 import Api from './Api';
 
+// two Apis initialized. one with auth and one without. 
+// this will be used more later when we actually implement auth
 const apiWithAuthToken = new Api('auth token');
 const apiWithoutAuthToken = new Api();
 
+// these tests do not actually test end to end. do we want to test end to end here?
 describe('getArtworks function', () => {
     it('auth token present fetch is called', async () => {
        global.fetch = jest.fn(() => {


### PR DESCRIPTION
fixes #5 

1. added a class to handle api calls to the back end services (only supports artwork now)
2. added jest as a dependency and created simple mock tests for methods in api class
3. updated gitignore to ignore coverage directory created from running tests